### PR TITLE
Permitidos equipos con nombres repetidos

### DIFF
--- a/app/controllers/EquipoController.java
+++ b/app/controllers/EquipoController.java
@@ -53,13 +53,13 @@ public class EquipoController extends Controller {
     @Security.Authenticated(ActionAuthenticator.class)
     public Result addUsuarioEquipo() {
         DynamicForm requestData = formFactory.form().bindFromRequest();
-        String equipo = requestData.get("equipo");
-        String usuario = requestData.get("usuario");
+        Long idEquipo = Long.parseLong(requestData.get("equipo"));
+        Long idUsuario = Long.parseLong(requestData.get("usuario"));
         try {
-            equipoService.addUsuarioEquipo(usuario, equipo);
-            return ok("Usuario " + usuario + " añadido al equipo " + equipo);
+            equipoService.addUsuarioEquipo(idUsuario, idEquipo);
+            return ok("Usuario " + idUsuario + " añadido al equipo " + idEquipo);
         } catch (EquipoServiceException exception) {
-            return notFound("No existe usuario / equipo");
+            return notFound(exception.getMessage());
         }
     }
 }

--- a/app/models/EquipoRepository.java
+++ b/app/models/EquipoRepository.java
@@ -11,7 +11,6 @@ public interface EquipoRepository {
 
     // Queries
     Equipo findById(Long idEquipo);
-    Equipo findByNombre(String nombre);
     List<Equipo> findAll();
-    List<Usuario> findUsuariosEquipo(String nombreEquipo);
+    List<Usuario> findUsuariosEquipo(Long idEquipo);
 }

--- a/app/models/JPAEquipoRepository.java
+++ b/app/models/JPAEquipoRepository.java
@@ -75,20 +75,6 @@ public class JPAEquipoRepository implements EquipoRepository {
     }
 
     @Override
-    public Equipo findByNombre(String nombre) {
-        return jpaApi.withTransaction(entityManager -> {
-            TypedQuery<Equipo> query = entityManager.createQuery(
-                    "select e from Equipo e where e.nombre = :nombre", Equipo.class);
-            try {
-                Equipo equipo = query.setParameter("nombre", nombre).getSingleResult();
-                return equipo;
-            } catch (NoResultException ex) {
-                return null;
-            }
-        });
-    }
-
-    @Override
     public List<Equipo> findAll() {
         return jpaApi.withTransaction(entityManager -> {
             TypedQuery<Equipo> query = entityManager.createQuery(
@@ -97,12 +83,12 @@ public class JPAEquipoRepository implements EquipoRepository {
         });
     }
 
-    public List<Usuario> findUsuariosEquipo(String nombreEquipo) {
+    public List<Usuario> findUsuariosEquipo(Long idEquipo) {
         return jpaApi.withTransaction(entityManager -> {
             TypedQuery<Usuario> query = entityManager.createQuery(
-                    "select u from Usuario u join u.equipos e where e.nombre = :nombreEquipo", Usuario.class);
+                    "select u from Usuario u join u.equipos e where e.id = :idEquipo", Usuario.class);
             try {
-                return query.setParameter("nombreEquipo", nombreEquipo).getResultList();
+                return query.setParameter("idEquipo", idEquipo).getResultList();
             } catch (NoResultException ex) {
                 return null;
             }

--- a/app/services/EquipoService.java
+++ b/app/services/EquipoService.java
@@ -17,10 +17,7 @@ public class EquipoService {
         this.usuarioRepository = usuarioRepository;
     }
 
-
     public Equipo addEquipo(String nombre) {
-        if (equipoRepository.findByNombre(nombre) != null)
-            throw new EquipoServiceException("Nombre de equipo ya existe: " + nombre);
         Equipo equipo = new Equipo(nombre);
         return equipoRepository.add(equipo);
     }
@@ -32,35 +29,35 @@ public class EquipoService {
         return equipos;
     }
 
-    public void addUsuarioEquipo(String login, String nombreEquipo) {
-        Equipo equipo = equipoRepository.findByNombre(nombreEquipo);
+    public void addUsuarioEquipo(Long idUsuario, Long idEquipo) {
+        Equipo equipo = equipoRepository.findById(idEquipo);
         if (equipo == null) {
-            throw new EquipoServiceException("No existe el equipo: " + nombreEquipo);
+            throw new EquipoServiceException("No existe el equipo: " + idEquipo);
         }
-        Usuario usuario = usuarioRepository.findByLogin(login);
+        Usuario usuario = usuarioRepository.findById(idUsuario);
         if (usuario == null) {
-            throw new EquipoServiceException("No existe el usuario con username: " + login);
+            throw new EquipoServiceException("No existe el usuario: " + idUsuario);
         }
         equipoRepository.addUsuarioEquipo(usuario, equipo);
     }
 
-    public void deleteUsuarioEquipo(String login, String nombreEquipo) {
-        Equipo equipo = equipoRepository.findByNombre(nombreEquipo);
+    public void deleteUsuarioEquipo(Long idUsuario, Long idEquipo) {
+        Equipo equipo = equipoRepository.findById(idEquipo);
         if (equipo == null) {
-            throw new EquipoServiceException("No existe el equipo: " + nombreEquipo);
+            throw new EquipoServiceException("No existe el equipo: " + idEquipo);
         }
-        Usuario usuario = usuarioRepository.findByLogin(login);
+        Usuario usuario = usuarioRepository.findById(idUsuario);
         if (usuario == null) {
-            throw new EquipoServiceException("No existe el usuario con username: " + login);
+            throw new EquipoServiceException("No existe el usuario con username: " + idUsuario);
         }
         equipoRepository.deleteUsuarioEquipo(usuario, equipo);
     }
 
-    public List<Usuario> findUsuariosEquipo(String nombreEquipo) {
+    public List<Usuario> findUsuariosEquipo(Long idEquipo) {
         List<Usuario> usuarios = new ArrayList<>();
-        Equipo equipo = equipoRepository.findByNombre(nombreEquipo);
+        Equipo equipo = equipoRepository.findById(idEquipo);
         if (equipo != null) {
-            usuarios = equipoRepository.findUsuariosEquipo(nombreEquipo);
+            usuarios = equipoRepository.findUsuariosEquipo(idEquipo);
         }
         return usuarios;
     }

--- a/app/views/formEquipoUsuario.scala.html
+++ b/app/views/formEquipoUsuario.scala.html
@@ -6,11 +6,11 @@
             <fieldset>
                 <legend>Añadir nuevo usuario a equipo</legend>
                 <p>
-                    <label>Nombre equipo: </label>
+                    <label>Id equipo: </label>
                     <input type="text" name="equipo" size="70">
                 </p>
                 <p>
-                    <label>Login usuario: </label>
+                    <label>Id usuario: </label>
                     <input type="text" name="usuario" size="40">
                 </p>
                 <p>

--- a/test/models/EquipoTest.java
+++ b/test/models/EquipoTest.java
@@ -130,7 +130,7 @@ public class EquipoTest {
 
         // Recuperamos las entidades de la base de datos y comprobamos
         // que los datos se han actualizado
-        List<Usuario> usuarios = equipoRepository.findUsuariosEquipo(equipo.getNombre());
+        List<Usuario> usuarios = equipoRepository.findUsuariosEquipo(equipo.getId());
         assertEquals(1, usuarios.size());
         Usuario usuarioBD = usuarioRepository.findById(1005L);
         assertEquals(2, usuarioBD.getEquipos().size());

--- a/test/services/EquipoServiceTest.java
+++ b/test/services/EquipoServiceTest.java
@@ -40,12 +40,6 @@ public class EquipoServiceTest {
         databaseTester.onSetup();
     }
 
-    @Test(expected = EquipoServiceException.class)
-    public void addEquipoNombreRepetido() {
-        EquipoService equipoService = injector.instanceOf(EquipoService.class);
-        equipoService.addEquipo("Equipo A");
-    }
-
     @Test
     public void listaEquipos() {
         EquipoService equipoService = injector.instanceOf(EquipoService.class);
@@ -57,7 +51,7 @@ public class EquipoServiceTest {
     public void addUsuarioEquipo() {
         EquipoService equipoService = injector.instanceOf(EquipoService.class);
         UsuarioService usuarioService = injector.instanceOf(UsuarioService.class);
-        equipoService.addUsuarioEquipo("juangutierrez", "Equipo C");
+        equipoService.addUsuarioEquipo(1000L, 1005L);
         Usuario usuario = usuarioService.findUsuarioPorLogin("juangutierrez");
         List<Equipo> equipos = new ArrayList(usuario.getEquipos());
         assertEquals(3, equipos.size());
@@ -67,7 +61,7 @@ public class EquipoServiceTest {
     public void getUsuariosEquipo() {
         EquipoService equipoService = injector.instanceOf(EquipoService.class);
         UsuarioService usuarioService = injector.instanceOf(UsuarioService.class);
-        List<Usuario> usuarios = equipoService.findUsuariosEquipo("Equipo A");
+        List<Usuario> usuarios = equipoService.findUsuariosEquipo(1003L);
         assertEquals(2, usuarios.size());
         Usuario usuario = usuarioService.findUsuarioPorLogin("anagarcia");
         assertEquals(1, usuario.getEquipos().size());
@@ -77,8 +71,8 @@ public class EquipoServiceTest {
     public void deleteUsuarioEquipo() {
         EquipoService equipoService = injector.instanceOf(EquipoService.class);
         UsuarioService usuarioService = injector.instanceOf(UsuarioService.class);
-        equipoService.deleteUsuarioEquipo("juangutierrez", "Equipo A");
-        List<Usuario> usuarios = equipoService.findUsuariosEquipo("Equipo A");
+        equipoService.deleteUsuarioEquipo(1000L, 1003L);
+        List<Usuario> usuarios = equipoService.findUsuariosEquipo(1003L);
         assertEquals(1, usuarios.size());
         Usuario usuario = usuarioService.findUsuarioPorLogin("juangutierrez");
         assertEquals(1, usuario.getEquipos().size());


### PR DESCRIPTION
Se modifican todos los métodos que usan el nombre como identificador del equipo para sustituirlo por su identificador.